### PR TITLE
delete unnecessary `"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,20 @@ exit status 2
 -> get each link following redirection and return working ones. (status code 200 / 302).
 ```
 ```
-▶ cat urls.txt | wurl -c 50 -H ""Cookie: mycookie" -s "200, 500, 302"
+▶ cat urls.txt | wurl -c 50 -H "Cookie: mycookie" -s "200, 500, 302"
 -> get each link using my cookie and return status codes [200, 500, 302]
 ```
 ```
-▶ cat urls.txt | wurl -c 50 -H ""Cookie: mycookie" -s "200, 500, 302" -p "http://192.168.0.150:8080"
+▶ cat urls.txt | wurl -c 50 -H "Cookie: mycookie" -s "200, 500, 302" -p "http://192.168.0.150:8080"
 -> get each link using my cookie and a proxy server (burp for example) and return status codes [200, 500, 302]
 ```
 ```
-▶ cat urls.txt | wurl -c 50 -H ""Cookie: mycookie" -s "200, 500, 302" -p "http://192.168.0.150:8080" -f "paypal"
+▶ cat urls.txt | wurl -c 50 -H "Cookie: mycookie" -s "200, 500, 302" -p "http://192.168.0.150:8080" -f "paypal"
 -> get each link using my cookie and a proxy server (burp for example).
 return status codes [200, 500, 302] and results containing the word "paypal" in his body.
 ```
 ```
-▶ cat urls.txt | wurl -c 50 -H ""Cookie: mycookie" -s "200, 500, 302" -p "http://192.168.0.150:8080" -f "paypal" --random-agent
+▶ cat urls.txt | wurl -c 50 -H "Cookie: mycookie" -s "200, 500, 302" -p "http://192.168.0.150:8080" -f "paypal" --random-agent
 -> get each link using my cookie, a random-agent for each query and a proxy server (burp for example).
 return status codes [200, 500, 302] and results containing the word "paypal" in his body.
 ```


### PR DESCRIPTION
删除example中多余的 `“` ,避免其他同学copy示例运行时报错